### PR TITLE
feat: Add list command to display configured MCP servers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Structure & Module Layout
 - `src/index.ts`: CLI entry point using `commander`.
-- `src/commands/*`: Subcommands (`add`, `remove`, `apply`, `agents add/remove`).
+- `src/commands/*`: Subcommands (`add`, `remove`, `apply`, `list`, `agents add/remove`).
 - `src/lib/config.ts`: JSON config loader/saver (default path `~/.mmcp.json`).
 - `src/lib/agents/*`: Agent adapters (e.g., `claude-code` writes `~/.claude.json`).
 - `scripts/build.ts`: Bun build script producing `dist/`.

--- a/README.md
+++ b/README.md
@@ -38,11 +38,27 @@ $ mmcp agents add claude-code
 
 ### 3. Apply your mmcp config to the agents
 
-```bash
+```console
 $ mmcp apply
 ```
 
 That’s it. Your MCP servers from `~/.mmcp.json` will be written into the agent’s config (e.g. `~/.claude.json` for Claude Code).
+
+### List configured servers
+
+```console
+$ mmcp list [--config <path>]
+context7: npx -y @upstash/context7-mcp@latest
+
+$ mmcp list --json
+{
+  "context7": {
+    "command": "npx",
+    "args": ["-y", "@upstash/context7-mcp@latest"],
+    "env": {}
+  }
+}
+```
 
 ## Configuration
 

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,0 +1,23 @@
+import { loadConfig } from "../lib/config";
+
+export type ListCommandParams = {
+  configPath: string; // --config
+  json: boolean; // --json
+};
+
+export function listCommand(params: ListCommandParams) {
+  const config = loadConfig({ path: params.configPath });
+
+  if (params.json) {
+    console.log(JSON.stringify(config.mcpServers, null, 2));
+    return;
+  }
+
+  const entries = Object.entries(config.mcpServers).sort(([a], [b]) =>
+    a.localeCompare(b),
+  );
+  for (const [name, server] of entries) {
+    const cmdline = [server.command, ...server.args].join(" ");
+    console.log(`${name}: ${cmdline}`);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { addCommand } from "./commands/add";
 import { agentsAddCommand } from "./commands/agents-add";
 import { agentsRemoveCommand } from "./commands/agents-remove";
 import { applyCommand } from "./commands/apply";
+import { listCommand } from "./commands/list";
 import { removeCommand } from "./commands/remove";
 import { supportedAgentIds } from "./lib/agents/registry";
 import { defaultConfigPath } from "./lib/config";
@@ -76,6 +77,15 @@ program
   .option("-c, --config <path>", "Path to config file", defaultConfigPath())
   .action((options: { agents?: string[]; config: string }) => {
     applyCommand({ agents: options.agents ?? [], configPath: options.config });
+  });
+
+program
+  .command("list")
+  .description("List configured mcp servers")
+  .option("-c, --config <path>", "Path to config file", defaultConfigPath())
+  .option("--json", "Output mcpServers as JSON", false)
+  .action((options: { config: string; json: boolean }) => {
+    listCommand({ configPath: options.config, json: options.json });
   });
 
 // agents subcommands


### PR DESCRIPTION
- Add new list command that displays configured MCP servers
- Support --json flag for JSON output format
- Update README with list command usage examples
- Sort server entries alphabetically in output

🤖 Generated with [Claude Code](https://claude.ai/code)