### PR TITLE
feat(agents): add Claude Desktop adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Manage your MCP (Model Context Protocol) server definitions in one place and app
 | Agent | id | Config Path |
 | --- | --- | --- |
 | [Claude Code](https://www.anthropic.com/claude-code) | `claude-code` | `~/.claude.json` |
+| [Claude Desktop](https://claude.ai/download) | `claude-desktop` | macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`<br>Windows: `%APPDATA%\Claude\claude_desktop_config.json`<br>Linux: `~/.config/Claude/claude_desktop_config.json` |
 | [Codex CLI](https://developers.openai.com/codex/cli) | `codex-cli` | `~/.codex/config.toml` |
 
 More agents may be added in the future.

--- a/src/lib/agents/claude-desktop.spec.ts
+++ b/src/lib/agents/claude-desktop.spec.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test";
+import type { Config } from "../config";
+import type { ClaudeDesktopConfig } from "./claude-desktop";
+import { mergeConfig } from "./claude-desktop";
+
+describe("mergeConfig (claude-desktop)", () => {
+  type Case = [
+    title: string,
+    agentConfig: ClaudeDesktopConfig,
+    mmcp: Config,
+    expected: ClaudeDesktopConfig,
+  ];
+
+  const cases: Case[] = [
+    [
+      "inserts new server into empty agent config",
+      {},
+      {
+        agents: ["claude-desktop"],
+        mcpServers: {
+          context7: {
+            command: "npx",
+            args: ["-y", "@upstash/context7-mcp@latest"],
+            env: {},
+          },
+        },
+      },
+      {
+        mcpServers: {
+          context7: {
+            command: "npx",
+            args: ["-y", "@upstash/context7-mcp@latest"],
+            env: {},
+          },
+        },
+      },
+    ],
+    [
+      "preserves other top-level keys and existing servers",
+      {
+        theme: "dark",
+        mcpServers: {
+          foo: { command: "node", args: ["foo.js"], env: { A: "1" } },
+        },
+      },
+      {
+        agents: [],
+        mcpServers: {
+          ctx: { command: "npx", args: [], env: {} },
+        },
+      },
+      {
+        theme: "dark",
+        mcpServers: {
+          foo: { command: "node", args: ["foo.js"], env: { A: "1" } },
+          ctx: { command: "npx", args: [], env: {} },
+        },
+      },
+    ],
+    [
+      "overwrites existing server and drops unknown keys under that server",
+      {
+        mcpServers: {
+          context7: { command: "old", args: ["-x"], env: {}, other: "stay" },
+        },
+      },
+      {
+        agents: [],
+        mcpServers: {
+          context7: { command: "npx", args: ["-y"], env: {} },
+        },
+      },
+      {
+        mcpServers: {
+          context7: { command: "npx", args: ["-y"], env: {} },
+        },
+      },
+    ],
+    [
+      "supports names with dot and space",
+      { mcpServers: {} },
+      {
+        agents: [],
+        mcpServers: {
+          "name.with dot": { command: "npx", args: [], env: { K: "V" } },
+        },
+      },
+      {
+        mcpServers: {
+          "name.with dot": { command: "npx", args: [], env: { K: "V" } },
+        },
+      },
+    ],
+    [
+      "empty mmcp servers results in no change",
+      { mcpServers: { keep: { command: "x", args: [], env: {} } } },
+      { agents: [], mcpServers: {} },
+      { mcpServers: { keep: { command: "x", args: [], env: {} } } },
+    ],
+  ];
+
+  test.each(cases)("%s", (_title, agentConfig, mmcp, expected) => {
+    const out = mergeConfig(structuredClone(agentConfig), mmcp);
+    expect(out).toEqual(expected);
+  });
+});

--- a/src/lib/agents/claude-desktop.ts
+++ b/src/lib/agents/claude-desktop.ts
@@ -1,0 +1,93 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { Config } from "../config";
+import type { AgentAdapter } from "./adapter";
+
+export type ClaudeDesktopConfig = {
+  mcpServers?: {
+    [name: string]: unknown;
+  };
+  // keep any other top-level keys
+  [key: string]: unknown;
+};
+
+export class ClaudeDesktopAgent implements AgentAdapter {
+  readonly id = "claude-desktop" as const;
+
+  applyConfig(config: Config): void {
+    const agentConfig = this._loadConfig();
+    const next = mergeConfig(agentConfig, config);
+    this._saveConfig(next);
+  }
+
+  private _configPath(): string {
+    const home = os.homedir();
+
+    // macOS
+    if (process.platform === "darwin") {
+      return path.join(
+        home,
+        "Library",
+        "Application Support",
+        "Claude",
+        "claude_desktop_config.json",
+      );
+    }
+
+    // Windows
+    if (process.platform === "win32") {
+      const appData = process.env.APPDATA;
+      if (!appData) {
+        throw new Error("Could not determine APPDATA directory.");
+      }
+      return path.join(appData, "Claude", "claude_desktop_config.json");
+    }
+
+    // Linux
+    return path.join(home, ".config", "Claude", "claude_desktop_config.json");
+  }
+
+  private _loadConfig(): ClaudeDesktopConfig {
+    const pathname = this._configPath();
+    if (!fs.existsSync(pathname)) {
+      return { mcpServers: {} };
+    }
+    const content = fs.readFileSync(pathname, "utf-8");
+    return JSON.parse(content);
+  }
+
+  private _saveConfig(config: ClaudeDesktopConfig): void {
+    const pathname = this._configPath();
+    const dir = path.dirname(pathname);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+    const content = `${JSON.stringify(config, null, 2)}\n`;
+    fs.writeFileSync(pathname, content, "utf-8");
+  }
+}
+
+export function mergeConfig(
+  agentConfig: ClaudeDesktopConfig,
+  config: Config,
+): ClaudeDesktopConfig {
+  const servers = Object.entries(config.mcpServers);
+  if (servers.length === 0) {
+    return agentConfig;
+  }
+
+  if (!agentConfig.mcpServers) {
+    agentConfig.mcpServers = {};
+  }
+
+  for (const [name, server] of Object.entries(config.mcpServers)) {
+    agentConfig.mcpServers[name] = {
+      command: server.command,
+      args: server.args,
+      env: server.env,
+    };
+  }
+
+  return agentConfig;
+}

--- a/src/lib/agents/registry.ts
+++ b/src/lib/agents/registry.ts
@@ -1,8 +1,13 @@
 import type { AgentAdapter } from "./adapter";
 import { ClaudeCodeAgent } from "./claude-code";
+import { ClaudeDesktopAgent } from "./claude-desktop";
 import { CodexCliAgent } from "./codex-cli";
 
-const agents: AgentAdapter[] = [new ClaudeCodeAgent(), new CodexCliAgent()];
+const agents: AgentAdapter[] = [
+  new ClaudeCodeAgent(),
+  new CodexCliAgent(),
+  new ClaudeDesktopAgent(),
+];
 
 export function getAgentById(id: string): AgentAdapter | undefined {
   return agents.find((a) => a.id === id);

--- a/src/lib/agents/registry.ts
+++ b/src/lib/agents/registry.ts
@@ -5,8 +5,8 @@ import { CodexCliAgent } from "./codex-cli";
 
 const agents: AgentAdapter[] = [
   new ClaudeCodeAgent(),
-  new CodexCliAgent(),
   new ClaudeDesktopAgent(),
+  new CodexCliAgent(),
 ];
 
 export function getAgentById(id: string): AgentAdapter | undefined {


### PR DESCRIPTION
- Add claude-desktop adapter and config path resolution
- Register agent in registry
- Add unit tests for mergeConfig
- Update README with OS-specific config paths
- Windows: require %APPDATA% (error: Could not determine APPDATA directory.)